### PR TITLE
Fix Filtering Issue

### DIFF
--- a/lib/src/posts.dart
+++ b/lib/src/posts.dart
@@ -23,7 +23,7 @@ class _PostsApi {
       'include': include,
       'fields': fields,
       'formats': formats,
-      'filters': filters,
+      'filter': filters,
     });
 
     return _map(json, 'posts', (e) => GhostPost.fromJson(e));


### PR DESCRIPTION
`filters` key name is wrong, so was not filtering any data with this library. Updated `filters` to `filter` which fixed the issue.