### PR TITLE
Add single filter option for browsing GhostPosts

### DIFF
--- a/lib/src/posts.dart
+++ b/lib/src/posts.dart
@@ -7,6 +7,7 @@ class _PostsApi {
 
   /// [formats] can be 'html' and 'plaintext'
   /// [include] can be 'authors' and 'tags'
+  /// [filter] can only be used if no [filters] are provided
   Future<List<GhostPost>> browse({
     int? page,
     int? limit,
@@ -15,6 +16,7 @@ class _PostsApi {
     List<String>? fields,
     List<String>? formats,
     List<String>? filters,
+    String? filter,
   }) async {
     final json = await _api.send('/posts', <String, dynamic>{
       'page': page,
@@ -23,7 +25,7 @@ class _PostsApi {
       'include': include,
       'fields': fields,
       'formats': formats,
-      'filter': filters,
+      'filter': filters ?? filter,
     });
 
     return _map(json, 'posts', (e) => GhostPost.fromJson(e));


### PR DESCRIPTION
### Fixing the filtering of ghost posts.

The current implementation allows only to do filtering with a logical OR like:
 filters: tags:[{tag1},{tag2},...]

In the new change its now possible to search for tags with logical AND, which matches more than one tags:
filter: tag:{tag1}+{tag2}