### PR TITLE
GhostPost PaginationInfo from Response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.0.5
+## 2.1.0
 
 - Added new GhostPost browse functionality to get PaginationInfo from meta data
 - Added types.dart to store new types

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.0.5
+
+- Added new GhostPost browse functionality to get PaginationInfo from meta data
+- Added types.dart to store new types
+- Added example to browser for ghost post with pagination info
+
 ## 2.0.4
 
 - Added missing GhostPost Properties from [GhostContentApi v5.80.4.](https://ghost.org/docs/content-api/#posts)

--- a/example/example.dart
+++ b/example/example.dart
@@ -11,12 +11,22 @@ Future<void> main() async {
     version: 'v3',
   );
 
+  print("Browse Ghost Posts");
   final posts = await api.posts.browse(
     limit: 5,
     include: ['tags', 'authors'],
   );
+  print('Found ${posts.length} posts:');
+  for (int idx = 0; idx < posts.length; idx++) {
+    print('${idx + 1}. ${posts[idx].title}');
+  }
 
-  for (final post in posts) {
-    print(post.title);
+  print("\nBrowse Ghost Posts with Pagination Info");
+  final postsWithPagination =
+      await api.posts.browseWithPaginationInfo(limit: 5);
+  print(postsWithPagination.paginationInfo);
+  print('Found ${postsWithPagination.posts.length} posts:');
+  for (int idx = 0; idx < postsWithPagination.posts.length; idx++) {
+    print('${idx + 1}. ${postsWithPagination.posts[idx].title}');
   }
 }

--- a/lib/src/api.dart
+++ b/lib/src/api.dart
@@ -9,7 +9,6 @@ part 'pages.dart';
 part 'posts.dart';
 part 'settings.dart';
 part 'tags.dart';
-part 'types.dart';
 
 class GhostContentAPI {
   final String url;
@@ -31,10 +30,7 @@ class GhostContentAPI {
       return '$value';
     };
 
-    final paramsString = params.entries
-        .where((e) => e.value != null)
-        .map((e) => '${e.key}=${valueToString(e.value)}')
-        .join('&');
+    final paramsString = params.entries.where((e) => e.value != null).map((e) => '${e.key}=${valueToString(e.value)}').join('&');
 
     final uri = '${url}/ghost/api/${version}/content${path}?$paramsString';
 
@@ -61,10 +57,7 @@ List<T> _map<T>(
   String name,
   T Function(Map<String, dynamic>) map,
 ) =>
-    (json[name] as List<dynamic>)
-        .cast<Map<String, dynamic>>()
-        .map(map)
-        .toList();
+    (json[name] as List<dynamic>).cast<Map<String, dynamic>>().map(map).toList();
 
 String _idOrSlugPath(String? id, String? slug) {
   if (id != null && slug != null) throw Error();

--- a/lib/src/api.dart
+++ b/lib/src/api.dart
@@ -9,6 +9,7 @@ part 'pages.dart';
 part 'posts.dart';
 part 'settings.dart';
 part 'tags.dart';
+part 'types.dart';
 
 class GhostContentAPI {
   final String url;

--- a/lib/src/api.g.dart
+++ b/lib/src/api.g.dart
@@ -39,6 +39,26 @@ Map<String, dynamic> _$GhostAuthorToJson(GhostAuthor instance) =>
       'url': instance.url,
     };
 
+PaginationInfo _$PaginationInfoFromJson(Map<String, dynamic> json) =>
+    PaginationInfo(
+      page: json['page'] as int?,
+      limit: json['limit'] as int?,
+      pages: json['pages'] as int?,
+      total: json['total'] as int?,
+      next: json['next'] as int?,
+      prev: json['prev'] as int?,
+    );
+
+Map<String, dynamic> _$PaginationInfoToJson(PaginationInfo instance) =>
+    <String, dynamic>{
+      'page': instance.page,
+      'limit': instance.limit,
+      'pages': instance.pages,
+      'total': instance.total,
+      'next': instance.next,
+      'prev': instance.prev,
+    };
+
 GhostPost _$GhostPostFromJson(Map<String, dynamic> json) => GhostPost(
       slug: json['slug'] as String?,
       id: json['id'] as String?,

--- a/lib/src/posts.dart
+++ b/lib/src/posts.dart
@@ -59,8 +59,7 @@ class _PostsApi {
     });
 
     final posts = _map(json, 'posts', GhostPost.fromJson);
-    final pagination = PaginationInfo.fromJson(
-        json['meta']['pagination'] as Map<String, dynamic>);
+    final pagination = PaginationInfo.fromJson(json['meta']['pagination'] as Map<String, dynamic>);
 
     return (paginationInfo: pagination, posts: posts);
   }
@@ -74,8 +73,7 @@ class _PostsApi {
     List<String>? include,
     List<String>? fields,
   }) async {
-    final json =
-        await _api.send('/posts/${_idOrSlugPath(id, slug)}', <String, dynamic>{
+    final json = await _api.send('/posts/${_idOrSlugPath(id, slug)}', <String, dynamic>{
       'formats': formats,
       'include': include,
       'fields': fields,
@@ -84,6 +82,8 @@ class _PostsApi {
     return _map(json, 'posts', (e) => GhostPost.fromJson(e)).first;
   }
 }
+
+typedef GhostPostResponse = ({PaginationInfo paginationInfo, List<GhostPost> posts});
 
 @JsonSerializable()
 class PaginationInfo {
@@ -108,8 +108,7 @@ class PaginationInfo {
     return 'PaginationInfo(limit: $limit, pages: $pages, total: $total, currentPage: $page,  next: $next, prev: $prev)';
   }
 
-  factory PaginationInfo.fromJson(Map<String, dynamic> json) =>
-      _$PaginationInfoFromJson(json);
+  factory PaginationInfo.fromJson(Map<String, dynamic> json) => _$PaginationInfoFromJson(json);
 
   Map<String, dynamic> toJson() => _$PaginationInfoToJson(this);
 }
@@ -196,8 +195,7 @@ class GhostPost {
     this.featureImageCaption,
   });
 
-  factory GhostPost.fromJson(Map<String, dynamic> json) =>
-      _$GhostPostFromJson(json);
+  factory GhostPost.fromJson(Map<String, dynamic> json) => _$GhostPostFromJson(json);
 
   Map<String, dynamic> toJson() => _$GhostPostToJson(this);
 }

--- a/lib/src/posts.dart
+++ b/lib/src/posts.dart
@@ -5,9 +5,11 @@ class _PostsApi {
 
   _PostsApi(this._api);
 
+  /// Browse posts without pagination
   /// [formats] can be 'html' and 'plaintext'
   /// [include] can be 'authors' and 'tags'
   /// [filter] can only be used if no [filters] are provided
+  /// Returns a list of list of [GhostPost]
   Future<List<GhostPost>> browse({
     int? page,
     int? limit,
@@ -31,6 +33,38 @@ class _PostsApi {
     return _map(json, 'posts', (e) => GhostPost.fromJson(e));
   }
 
+  /// Browse posts with pagination info
+  /// [formats] can be 'html' and 'plaintext'
+  /// [include] can be 'authors' and 'tags'
+  /// [filter] can only be used if no [filters] are provided
+  /// Returns a [GhostPostResponse] with a list of posts and pagination info
+  Future<GhostPostResponse> browseWithPaginationInfo({
+    int? page,
+    int? limit,
+    String? order,
+    List<String>? include,
+    List<String>? fields,
+    List<String>? formats,
+    List<String>? filters,
+    String? filter,
+  }) async {
+    final json = await _api.send('/posts', <String, dynamic>{
+      'page': page,
+      'limit': limit,
+      'order': order,
+      'include': include,
+      'fields': fields,
+      'formats': formats,
+      'filter': filters ?? filter,
+    });
+
+    final posts = _map(json, 'posts', GhostPost.fromJson);
+    final pagination = PaginationInfo.fromJson(
+        json['meta']['pagination'] as Map<String, dynamic>);
+
+    return (paginationInfo: pagination, posts: posts);
+  }
+
   /// [formats] can be 'html' and 'plaintext'
   /// [include] can be 'authors' and 'tags'
   Future<GhostPost> read({
@@ -49,6 +83,35 @@ class _PostsApi {
 
     return _map(json, 'posts', (e) => GhostPost.fromJson(e)).first;
   }
+}
+
+@JsonSerializable()
+class PaginationInfo {
+  final int? page;
+  final int? limit;
+  final int? pages;
+  final int? total;
+  final int? next;
+  final int? prev;
+
+  PaginationInfo({
+    required this.page,
+    required this.limit,
+    required this.pages,
+    required this.total,
+    required this.next,
+    required this.prev,
+  });
+
+  @override
+  toString() {
+    return 'PaginationInfo(limit: $limit, pages: $pages, total: $total, currentPage: $page,  next: $next, prev: $prev)';
+  }
+
+  factory PaginationInfo.fromJson(Map<String, dynamic> json) =>
+      _$PaginationInfoFromJson(json);
+
+  Map<String, dynamic> toJson() => _$PaginationInfoToJson(this);
 }
 
 @JsonSerializable()

--- a/lib/src/types.dart
+++ b/lib/src/types.dart
@@ -1,0 +1,6 @@
+part of 'api.dart';
+
+typedef GhostPostResponse = ({
+  PaginationInfo paginationInfo,
+  List<GhostPost> posts
+});

--- a/lib/src/types.dart
+++ b/lib/src/types.dart
@@ -1,6 +1,0 @@
-part of 'api.dart';
-
-typedef GhostPostResponse = ({
-  PaginationInfo paginationInfo,
-  List<GhostPost> posts
-});

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: ghost
-version: 2.0.3
+version: 2.1.0
 description: Ghost CMS API client that closely follows the official implementation
 homepage: https://github.com/0xVesion/dart_ghost
 


### PR DESCRIPTION
## GhostPost Pagination from browse Response

To handle the Pagination of a GhostPosts, we need to get the PaginationInfo of the meta data inside the response:

![image](https://github.com/0xVesion/dart_ghost/assets/62246969/6d3bbb74-aa56-4dbf-aa54-5d32519c1a90)

- Added new browse function to browse for a ghost post and receive a list of posts and the pagination info from the request.
- Updated Example
- Updated CHANGELOG.md

